### PR TITLE
Fix C906 PTE flag strong order bit issue. Add PLIC support for the use of external interrupts handling on c906 platform.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "plictest"
+version = "0.1.0"
+dependencies = [
+ "axhal",
+ "axlog",
+ "libax",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "apps/task/sleep",
     "apps/task/yield",
     "apps/task/priority",
+    "apps/plictest",
 
     "crates/allocator",
     "crates/arm_gic",

--- a/apps/plictest/Cargo.toml
+++ b/apps/plictest/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "plictest"
+version = "0.1.0"
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libax = { path = "../../ulib/libax", features = ["paging", "irq"] }
+axhal = { path = "../../modules/axhal"}
+axlog = { path = "../../modules/axlog"}

--- a/apps/plictest/src/main.rs
+++ b/apps/plictest/src/main.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![no_main]
+extern crate axhal;
+use axlog::*;
+use core::ptr::{read_volatile, write_volatile};
+use axhal::mem::phys_to_virt;
+
+#[no_mangle]
+fn main() {
+    libax::println!("C906 PLIC Interrupt Test app, testing PLIC external interrupts on c906 platform!");    
+    libax::println!("Step1: register an irq handler for external interrupt number 32");    
+    libax::println!("Step2: write 1 to the interrupt bit of irqn32 to its Interrupt Pending register PLIC_IPx");    
+    libax::println!("Step3: wait for the interrupt handling process to run!");    
+    let plic_base = 0x7000_0000;
+    let plic_ip0_offset = 0x000_1000;
+    axhal::irq::register_handler_common(32, ||{
+        info!("irq_num:32, interrupt handling process is running.");
+    });
+
+    unsafe{
+        info!("Trying writes 1 to PLIC_IP register for irq_num:32 ");
+        let plic_ip_va = phys_to_virt((plic_base + plic_ip0_offset + 4 * (32 / 32)).into()).as_usize() as *mut u32;
+        let ori = read_volatile(plic_ip_va);
+        write_volatile(plic_ip_va, ori | 1 << (32 % 32));
+        info!("write interrupt pending register completes, waiting for interrupt handling process");
+    }
+}

--- a/modules/axconfig/src/platform/qemu-virt-riscv.toml
+++ b/modules/axconfig/src/platform/qemu-virt-riscv.toml
@@ -20,8 +20,9 @@ mmio-regions = [
     ["0x7000_0000","0x4000000"],     # PLIC for cvitek
     ["0x1000_0000", "0x1000"],      # UART
     ["0x1000_1000", "0x8000"],      # VirtIO
-    ["0x3000_0000", "0x1000_0000"],  # PCI config space
-    #["0x4000_0000", "0x4000_0000"],  # PCI memory ranges (ranges 1: 32-bit MMIO space)
+    # ["0x3000_0000", "0x1000_0000"],  # PCI config space
+    # ["0x4000_0000", "0x4000_0000"],  # PCI memory ranges (ranges 1: 32-bit MMIO space)
+    ["0x7000_0000", "0x400_0000"],  # C906 PLIC
     ["0x0300_0000", "0x6_0000"],
     ["0x0451_0000", "0x1_0000"],    # ethernet0
     ["0x0452_0000", "0x1_0000"],    # ethernet1

--- a/modules/axhal/src/platform/qemu_virt_riscv/irq.rs
+++ b/modules/axhal/src/platform/qemu_virt_riscv/irq.rs
@@ -4,7 +4,7 @@ use crate::irq::IrqHandler;
 use lazy_init::LazyInit;
 use riscv::register::sie;
 use core::ptr::{read_volatile,write_volatile};
-use crate::mem::*;
+use crate::mem::{phys_to_virt, virt_to_phys};
 
 /// `Interrupt` bit in `scause`
 pub(super) const INTC_IRQ_BASE: usize = 1 << (usize::BITS - 1);
@@ -22,10 +22,17 @@ pub(super) const S_EXT: usize = INTC_IRQ_BASE + 9;
 static TIMER_HANDLER: LazyInit<IrqHandler> = LazyInit::new();
 
 /// The maximum number of IRQs.
-pub const MAX_IRQ_COUNT: usize = 1024;
+pub const MAX_IRQ_COUNT: usize = 128;
 
 /// The timer IRQ number (supervisor timer interrupt in `scause`).
 pub const TIMER_IRQ_NUM: usize = S_TIMER;
+
+const PLIC_BASE:usize = 0x7000_0000;
+const PLIC_PRIO1_OFFSET:usize   = 0x0;
+const PLIC_IP0_OFFSET:usize     = 0x000_1000;
+const PLIC_H0_SIE0_OFFSET:usize = 0x000_2080;
+const PLIC_H0_STH_OFFSET:usize  = 0x020_1000;
+const PLIC_SCLAIM_OFFSET:usize  = 0x020_1004;
 
 macro_rules! with_cause {
     ($cause: expr, @TIMER => $timer_op: expr, @EXT => $ext_op: expr $(,)?) => {
@@ -38,34 +45,48 @@ macro_rules! with_cause {
 }
 
 /// Enables or disables the given IRQ.
-pub fn set_enable(scause: usize, _enabled: bool) {
-    info!("go into set enable\n");
-    let PLIC_OFF:usize=0x7000_0000;
-    let x:u32=(scause as u32)/32;
-    let y:u32=(scause as u32)%32;
-    let PLIC_H0_MIE0:usize=0x0000_2000;
+pub fn set_enable(irq_num: usize, _enabled: bool) {
+    // if scause == S_EXT {
+    // TODO: set enable in PLIC
+    // let irqn = scause & !
+    let x:u32 = (irq_num as u32) / 32;
+    let y:u32 = (irq_num as u32) % 32;
     
-    let PLIC_H:usize=PLIC_OFF+PLIC_H0_MIE0+x as usize;
-    let PLIC_MIE:usize=1<<y;
+    let plic_prio_reg_addr = PLIC_BASE + 4*irq_num as usize;
+    let plic_h0_sie_reg_addr:usize = PLIC_BASE + PLIC_H0_SIE0_OFFSET + 4*x as usize;
+    let plic_h0_sie_reg_enable_mask:u32 = 1 << y;
 
-    info!("start test plic read1");
+    // info!("Plic enable for irq_num:{}!\n",irq_num);
 
-    ///let PLIC_H = 0x1000_0000;
     unsafe{
-        let addr=usize::from(phys_to_virt((PLIC_OFF+0x4).into()));
-        info!("addr {:#x}",addr);
-        let curr_reg_num=read_volatile(addr as *mut u32);
-        info!("the plic h is {}",curr_reg_num);
+        let plic_h0_sie_reg_va:*mut u32 = phys_to_virt(plic_h0_sie_reg_addr.into()).as_usize() as *mut u32;
+        let plic_prio_reg_va:*mut u32 = phys_to_virt(plic_prio_reg_addr.into()).as_usize() as *mut u32;
+
+        // info!("The plic_h0_sie_reg_va:{:#x}", phys_to_virt(plic_h0_sie_reg_addr.into()).as_usize());
+        let sie_curr_reg_value = read_volatile(plic_h0_sie_reg_va);
+        // info!("The sie_curr_reg_value is {:#x}", sie_curr_reg_value);
+
+        if _enabled {
+            let prio = read_volatile(plic_prio_reg_va);
+            // setup external interupt source's priority.  irqn's priority, 0 means it will not be handlers.
+            if prio != 7 {
+                write_volatile(plic_prio_reg_va, 7); // c906 support 0-31
+            }
+            // enable external interupt for this irqn/interupt source
+            write_volatile(plic_h0_sie_reg_va, sie_curr_reg_value | plic_h0_sie_reg_enable_mask);              
+        }else{
+            // disable interrupt for this irq_num
+            write_volatile(plic_h0_sie_reg_va, sie_curr_reg_value & !plic_h0_sie_reg_enable_mask);     
+        }
+
+        let sie_curr_reg_value = read_volatile(plic_h0_sie_reg_va);
+        // info!("The sie_curr_reg_value after write volatile: {}", sie_curr_reg_value);
     }
-    if scause == S_EXT {
-        // TODO: set enable in PLIC
-        // let PLIC_OFF:usize=0x0c00_0000;
-        
-        
-    }
+    // remember to setup PLIC_TH reg during interrupt init!  set it to 0 to allow all the external interrupt sources / irqns.
+    // }
 }
 
-/// Registers an IRQ handler for the given IRQ.
+/// Registers an handler for Timer interrupt only
 ///
 /// It also enables the IRQ if the registration succeeds. It returns `false` if
 /// the registration failed.
@@ -94,7 +115,24 @@ pub fn dispatch_irq(scause: usize) {
             trace!("IRQ: timer");
             TIMER_HANDLER();
         },
-        @EXT => crate::irq::dispatch_irq_common(0), // TODO: get IRQ number from PLIC
+        @EXT => {
+            let plic_sclaim_va = phys_to_virt((PLIC_BASE + PLIC_SCLAIM_OFFSET).into()).as_usize() as *mut u32;
+            let mut pending_int_irqn:u32 = 0;
+            unsafe {
+                // reading PLIC sclaim register to get the interrupt that is pending for handle
+                pending_int_irqn = read_volatile(plic_sclaim_va);                
+            }
+            // 0 means no interrupt pending
+            if pending_int_irqn != 0{                
+                // sie::clear_sie(); // disable external int, 
+                crate::irq::dispatch_irq_common(pending_int_irqn as usize); // TODO: get IRQ number from PLIC
+                // sie::set_sie();
+            }
+            unsafe{
+                // write back to sclaim register, indicating we have completed interrupt handling
+                write_volatile(plic_sclaim_va,pending_int_irqn);   
+            }
+        }
     );
 }
 
@@ -105,4 +143,28 @@ pub(super) fn init_percpu() {
         sie::set_stimer();
         sie::set_sext();
     }
+    // disable all interrupts and set priority of all interrupts to 1
+    #[cfg(feature = "irq")]
+    for i in 1..MAX_IRQ_COUNT{
+        set_enable(i, false); // disable all interrupts, enable them when register a handler for them
+        plic_prio_init(i as u32, 1); // set priority of all interrupts to 1 in advance
+    }
+    // setup plic threshold to 0
+    #[cfg(feature = "irq")]
+    plic_threshold_setup(0);
+
+}
+
+fn plic_threshold_setup(threshold: u32){
+    let plic_h0_sth_va = phys_to_virt((PLIC_BASE + PLIC_H0_STH_OFFSET).into()).as_usize() as *mut u32;
+    // write 0 to plic_h0_sth to enable all the interrupts.
+    unsafe{
+        write_volatile(plic_h0_sth_va, threshold); 
+    }
+}
+
+fn plic_prio_init(irq_num:u32, val:u32){
+    let plic_prio_reg_addr = PLIC_BASE + 4*irq_num as usize;
+    let plic_prio_reg_va:*mut u32 = phys_to_virt(plic_prio_reg_addr.into()).as_usize() as *mut u32;
+    unsafe{write_volatile(plic_prio_reg_va, val); }
 }


### PR DESCRIPTION
1). Update page_table_entry crate to adapt PTE flags to support C906 Strong Order bit, resolving mmio device registers accessibility issue like PLIC registers. 
2). Add PLIC interrupt init, interrupt handler register, interrupt dispatch and handling support for C906 platform. 
3). Add plictest app.